### PR TITLE
fix README.md netlify blue button link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It downloads original image and transforms it with [Sharp](https://github.com/lo
 
 You need to deploy the functions to Netlify:
 
-[![Deploy](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/himshim/bandwidth-hero-proxy2)
+[![Deploy](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/ukind/bandwidth-hero-proxy2)
 
 Then, in the **Data Compression Service** in Bandwidth Hero extension, add `https://your-netlify-domain.netlify.app/api/index`, and you are good to go.
 


### PR DESCRIPTION
just fixed the small issue which is the wrong link on the netlify blue button on readme file on main page. it was pointing to another repository not this one.

see [https://github.com/ukind/bandwidth-hero-proxy2/issues/14](url)